### PR TITLE
Fix HTML escaping

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,11 +26,11 @@
         body {
             background-color: #0E0E0E;
         }
-        
-        
+
+
 
         #wrapper {
-           
+
         }
 
         #wrapper .column {
@@ -114,7 +114,7 @@
             overflow:auto;
         }
 
-        
+
 
 
         .module.settings ul {
@@ -265,7 +265,7 @@
         }
 
         #settings ul li input {
-            
+
         }
 
         #settings footer {
@@ -517,8 +517,8 @@
             catch{}
 
             $('.module').each(function () {
-                
-                
+
+
                 var id = $(this).attr('id');
 
                 if (!config[id])
@@ -576,7 +576,7 @@
             });
 
 
-           
+
 
             GetGlobalBadges();
             LoadCheerEmotes();
@@ -664,7 +664,7 @@
             config.Channel = txtChannel.value.toLowerCase();
             config.Nick = txtNick.value;
             config.Pass = txtPass.value;
-              
+
 
             //client.JoinChannels(txtChannel.value.toLowerCase());
             localStorage.setItem('config', JSON.stringify(config));

--- a/index.html
+++ b/index.html
@@ -651,6 +651,13 @@
             InitClient();
         })();
 
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            const textNode = document.createTextNode(text);
+            div.appendChild(textNode);
+            return div.innerHTML;
+        }
+
 
         function UpdateChannelTimer() {
             clearTimeout(channelTimerId);
@@ -826,13 +833,13 @@
                 user_col = user_undefined_colors[user];
             }
 
+            message = escapeHtml(message);
+
             var message_col = '';
             if (message.indexOf('ACTION') == 0) {
                 message_col = `color: ${user_col}`;
                 message = message.substring(8, message.length - 1);
             }
-
-            message = message.replace(/</g, '&lt;').replace(/>/g, '&gt');
 
             //replace chat emote keywords with actual emote images
             if (userData.emotes != "") {


### PR DESCRIPTION
Uses DOM nodes to escape HTML entities. This is safer, as it uses the browser's method of escaping HTML entities within text nodes (`createTextNode`).